### PR TITLE
Add GetResponseMessageOrThrow to ApiTesting

### DIFF
--- a/testing/Smusdi.Testing/Http/ApiTesting.cs
+++ b/testing/Smusdi.Testing/Http/ApiTesting.cs
@@ -11,7 +11,7 @@ public sealed class ApiTesting(SmusdiServiceTestingSteps smusdiServiceTestingSte
 
     public HttpResponseMessage? ResponseMessage { get; set; }
 
-    public HttpResponseMessage GetHttpResponseMessageOrThrow()
+    public HttpResponseMessage GetResponseMessageOrThrow()
         => this.ResponseMessage ?? throw new InvalidOperationException("ResponseMessage is null. Did you forget to call an HTTP method?");
 
     public Task Get(string uri) => this.SendRequest(uri, HttpMethod.Get);

--- a/testing/Smusdi.Testing/Http/ApiTesting.cs
+++ b/testing/Smusdi.Testing/Http/ApiTesting.cs
@@ -11,6 +11,9 @@ public sealed class ApiTesting(SmusdiServiceTestingSteps smusdiServiceTestingSte
 
     public HttpResponseMessage? ResponseMessage { get; set; }
 
+    public HttpResponseMessage GetHttpResponseMessageOrThrow()
+        => this.ResponseMessage ?? throw new InvalidOperationException("ResponseMessage is null. Did you forget to call an HTTP method?");
+
     public Task Get(string uri) => this.SendRequest(uri, HttpMethod.Get);
 
     public Task Delete(string uri) => this.SendRequest(uri, HttpMethod.Delete);


### PR DESCRIPTION
Introduce GetHttpResponseMessageOrThrow() to safely retrieve the HTTP response message or throw an exception if it is null, ensuring that an HTTP method was called before accessing the response.